### PR TITLE
Fixes Issue 16 import fails silently

### DIFF
--- a/webform_import.module
+++ b/webform_import.module
@@ -361,7 +361,10 @@ function _webform_import_import($form, $form_state, $file) {
       foreach ($data as $k => &$cell_value) {
         $cell_value = _webform_import_csvfieldtrim($cell_value);
         if ($cell_value && !$components_list[$cell_value]) {
-          backdrop_set_message(t('Can not find column @k in components list, skipping.', array('@k' => $cell_value)), 'warning');
+          // Go to the next row and reset the counter because this isn't the real webform table header.
+          backdrop_set_message(t('Can not find column @k in components list, skipping row.', array('@k' => $cell_value)), 'warning');
+          $count--;
+          continue;
         }
         elseif (isset($components_list[$cell_value]['cid'])) {
           $cids[$k] = $components_list[$cell_value]['cid'];

--- a/webform_import.module
+++ b/webform_import.module
@@ -319,7 +319,7 @@ function _webform_import_import($form, $form_state, $file) {
   $field_key = $form_state['values']['field_keys'];
 
   // When importing using Field Names, set up the form keys for each field name.
-  if ($field_key === 'name') { 
+  if ($field_key === 'name') {
     $components_list['Serial'] = array('form_key' => 'webform_serial');
     $components_list['SID'] = array('form_key' => 'webform_sid');
     $components_list['Submitted Time'] = array('form_key' => 'webform_time');
@@ -479,19 +479,31 @@ function _webform_import_import($form, $form_state, $file) {
         'modified' => $modified,
         'remote_addr' => $ipaddress,
         'is_draft' => FALSE,
-	// Use the row counter as the serial number if it's missing (NULL). 
-	// It needs to be unique or it will cause a DB error.
-        'serial' => $serial ?? $count, 
+        // Use the row counter as the serial number if it's missing (NULL).
+        // It needs to be unique or it will cause a DB error.
+        'serial' => $serial ?? $count,
         'data' => webform_submission_data($webform, $sub_array),
       );
 
-      // Determine whether to INSERT or UPDATE based on inclusion of SID.
+      // If there is no SID, assume it is a new record and insert it.
       if ($sid != NULL) {
         $submission->sid = $sid;
-        $sids[] = webform_submission_update($webform, $submission);
+        // Check whether this record is in the DB already and update if yes or insert if no.
+        $result = db_query("SELECT sid FROM {webform_submissions} WHERE sid = $sid AND nid = $submission->nid");
+        if ($result->rowCount()) {
+          backdrop_set_message(t('Updating submission with SID @sid', array('@sid'=>$sid)), 'information');
+          $sids[] = webform_submission_update($webform, $submission);
+        }
+        else {
+          backdrop_set_message(t('Creating new submission with SID @sid', array('@sid'=>$sid)), 'information');
+          // webform_submission_insert does not write to the webform_submissions table if SID is set, so we do it ourselves.
+          backdrop_write_record('webform_submissions', $submission);
+          $sids[] = webform_submission_insert($webform, $submission);
+        }
       }
       else {
         $sids[] = webform_submission_insert($webform, $submission);
+        backdrop_set_message(t('Creating new submission'), 'information');
       }
     }
     else {


### PR DESCRIPTION
Replaced the method of simply looking whether an SID exists for the imported submission with actually querying the DB to confirm whether the submission exists in the current (importing) site's DB. Also added a write to add the locally-new submission to the webform_submissions table.